### PR TITLE
Add location subscription

### DIFF
--- a/app/controllers/butterfli/instagram/rails/api_controller.rb
+++ b/app/controllers/butterfli/instagram/rails/api_controller.rb
@@ -4,6 +4,15 @@ class Butterfli::Instagram::Rails::ApiController < Butterfli::Controller
 
   before_action :is_signed?
 
+  def setup
+    response = client.meet_challenge(params) { |token| true }
+    respond_to do |format|
+      format.html { render text: response }
+      format.json { render text: response }
+      format.text { render text: response }
+    end
+  end
+
   protected
   def client
     @client ||= Butterfli.configuration.providers(:instagram).client

--- a/app/controllers/butterfli/instagram/rails/subscription/geography_controller.rb
+++ b/app/controllers/butterfli/instagram/rails/subscription/geography_controller.rb
@@ -1,13 +1,4 @@
 class Butterfli::Instagram::Rails::Subscription::GeographyController < Butterfli::Instagram::Rails::ApiController
-  def setup
-    response = client.meet_challenge(params) { |token| true }
-    respond_to do |format|
-      format.html { render text: response }
-      format.json { render text: response }
-      format.text { render text: response }
-    end
-  end
-
   def callback
     geo_object_id = nil
     media_objects = nil

--- a/app/controllers/butterfli/instagram/rails/subscription/location_controller.rb
+++ b/app/controllers/butterfli/instagram/rails/subscription/location_controller.rb
@@ -1,0 +1,46 @@
+class Butterfli::Instagram::Rails::Subscription::LocationController < Butterfli::Instagram::Rails::ApiController
+  def callback
+    loc_object_id = nil
+    media_objects = nil
+
+    # Step #1: Callback to Instagram and retrieve the media metadata
+    client.process_subscription(request.raw_post) do |handler|
+      handler.on_location_changed do |id, data|
+        loc_object_id = id
+        media_objects = client.location_recent_media(loc_object_id, min_id: subscriptions[loc_object_id])
+      end
+    end
+    
+    # Step #2: Filter images to uniques
+    media_objects = media_objects.uniq { |item| item['id'] }
+
+    stories = []
+    if !media_objects.empty?
+      # Step #3: Transform image metadata using Butterfli
+      media_objects.each do |media_object|
+        story = Butterfli::Instagram::Data::MediaObject.new(media_object).transform
+        stories << story if story
+      end
+      
+      # Step #3.1: Update the 'last seen photo ID', for 'pagination'
+      # NOTE: If we're receiving objects from multiple overlapping locations,
+      #       it's entirely possible we'd be collecting duplicate stories...
+      subscriptions[loc_object_id] = media_objects.collect(&:id).max
+    end
+
+    # Step #4: Notify Instagram subscribers
+    Butterfli.syndicate(stories) if !stories.empty?
+
+    # Step #5: Render output
+    respond_to do |format|
+      format.html { render text: "#{stories.to_json}" }
+      format.json { render text: "#{stories.to_json}" }
+      format.text { render text: "#{stories.to_json}" }
+    end
+  end
+
+  private
+  def subscriptions
+    @@subscriptions ||= {}
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,10 @@ Butterfli::Instagram::Rails::Engine.routes.draw do
         get 'callback', to: '/butterfli/instagram/rails/subscription/geography#setup'
         post 'callback', to: '/butterfli/instagram/rails/subscription/geography#callback'
       end
+      namespace :location do
+        get 'callback', to: '/butterfli/instagram/rails/subscription/location#setup'
+        post 'callback', to: '/butterfli/instagram/rails/subscription/location#callback'
+      end
     end
   end
 end

--- a/lib/butterfli/instagram/rails/tasks.rb
+++ b/lib/butterfli/instagram/rails/tasks.rb
@@ -5,6 +5,7 @@ module Butterfli::Instagram::Tasks
 
   engine Butterfli::Instagram::Rails::Engine
   controller :geography, "Butterfli::Instagram::Rails::Subscription::GeographyController"
+  controller :location, "Butterfli::Instagram::Rails::Subscription::LocationController"
 
   # NOTE: Must be forcefully overidden to use the Rails module...
   def self.configure; super; end

--- a/spec/controllers/subscription/location_controller_spec.rb
+++ b/spec/controllers/subscription/location_controller_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+RSpec.describe Butterfli::Instagram::Rails::Subscription::LocationController, type: :controller do
+  routes { Butterfli::Instagram::Rails::Engine.routes }
+
+  # Configure the Instagram client...
+  before { configure_for_instagram }
+
+  # Define expected behaviors for each endpoint:
+  describe "#setup" do
+    context "when called with a typical Instagram setup request" do
+      let(:req) { request_fixture("subscription/location/setup/default") }
+      subject { execute_fixtured_action(:setup, req) }
+      it do
+        expect(subject).to have_http_status(:ok)
+        expect(subject.body).to eq(req['query_string']['hub.challenge'])
+      end
+    end
+  end
+  describe "#callback" do
+    let(:target) { double("callback_target") }
+
+    before(:each) { Butterfli.subscribe { |stories| target.share(stories) } }
+    after(:each) { Butterfli.unsubscribe_all }
+
+    context "when called with a typical Instagram callback request" do
+      let(:req) { request_fixture("subscription/location/callback/default") }
+      subject { execute_fixtured_action(:callback, req) }
+
+      it do
+        VCR.use_cassette("subscription/location/callback/default") do
+          expect(target).to receive(:share)
+          expect(subject).to have_http_status(:ok)
+          expect(JSON.parse(subject.body).length).to eq(2)
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/inbound/subscription/location/callback/default.yml
+++ b/spec/fixtures/inbound/subscription/location/callback/default.yml
@@ -1,0 +1,24 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:3000/instagram/subscription/location/callback
+    path: "/instagram/subscription/location/callback"
+    query_string: ""
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"changed_aspect": "media", "object": "location", "object_id": "254433809",
+        "time": 1439604298, "subscription_id": 19726930, "data": {}}]'
+    headers:
+      Host:
+      - localhost:3000
+      X-Hub-Signature:
+      - c3bf5b9a5286fa4831050df0e2581b034a7f945e
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Python-httplib2/0.8 (gzip)
+      Version:
+      - HTTP/1.1
+  recorded_at: '2015-08-14T22:05:12-04:00'
+recorded_with: Butterfli Rack Recorder

--- a/spec/fixtures/inbound/subscription/location/setup/default.yml
+++ b/spec/fixtures/inbound/subscription/location/setup/default.yml
@@ -1,0 +1,21 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3000/?hub.challenge=30f18cedbe3941ea9fd57967d8402922&hub.mode=subscribe
+    path: "/"
+    query_string: hub.challenge=30f18cedbe3941ea9fd57967d8402922&hub.mode=subscribe
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Host:
+      - localhost:3000
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Python-httplib2/0.8 (gzip)
+      Version:
+      - HTTP/1.1
+  recorded_at: '2015-08-14T15:31:00-04:00'
+recorded_with: Butterfli Rack Recorder

--- a/spec/fixtures/outbound/subscription/location/callback/default.yml
+++ b/spec/fixtures/outbound/subscription/location/callback/default.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.instagram.com/v1/locations/254433809/media/recent.json?min_id&client_id=client_id
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json; charset=utf-8
+      User-Agent:
+      - Instagram Ruby Gem 1.1.5
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      x-ratelimit-remaining:
+      - '4994'
+      content-language:
+      - en
+      expires:
+      - Sat, 01 Jan 2000 00:00:00 GMT
+      vary:
+      - Cookie, Accept-Language, Accept-Encoding
+      x-ratelimit-limit:
+      - '5000'
+      pragma:
+      - no-cache
+      cache-control:
+      - private, no-cache, no-store, must-revalidate
+      date:
+      - Sat, 15 Aug 2015 02:09:07 GMT
+      content-type:
+      - application/json; charset=utf-8
+      set-cookie:
+      - csrftoken=323258bae9c2f6f3f379dd1d752818f9; expires=Sat, 13-Aug-2016 02:09:07
+        GMT; Max-Age=31449600; Path=/
+      connection:
+      - keep-alive
+      content-length:
+      - '1234'
+    body:
+      encoding: UTF-8
+      string: '{"pagination":{"next_url":"https:\/\/api.instagram.com\/v1\/locations\/254433809\/media\/recent?max_id=995119922728364795\u0026client_id=f3fe014c5b9e4ef9982b94224a5083f4","next_max_id":"995119922728364795"},"meta":{"code":200},"data":[{"attribution":null,"tags":["centralpark"],"location":{"latitude":40.783055556,"name":"Central Park","longitude":-73.972222222,"id":254433809},"comments":{"count":0,"data":[]},"filter":"Normal","created_time":"1432856839","link":"https:\/\/instagram.com\/p\/3Ppxa7Jhzm\/","likes":{"count":73,"data":[{"username":"jiioohanna","profile_picture":"https:\/\/igcdn-photos-h-a.akamaihd.net\/hphotos-ak-xfp1\/t51.2885-19\/10808598_374620332702751_859404116_a.jpg","id":"1379990930","full_name":"Johanna"},{"username":"nesselias","profile_picture":"https:\/\/igcdn-photos-c-a.akamaihd.net\/hphotos-ak-xaf1\/t51.2885-19\/s150x150\/11849149_1136441666385930_687093798_a.jpg","id":"990856922","full_name":"vanessa"},{"username":"caltij","profile_picture":"https:\/\/scontent.cdninstagram.com\/hphotos-xaf1\/t51.2885-19\/11821293_1458279234497420_965456874_a.jpg","id":"1068198853","full_name":"Jo-Ann Caltabiano"},{"username":"_sahilverma","profile_picture":"https:\/\/igcdn-photos-a-a.akamaihd.net\/hphotos-ak-xaf1\/t51.2885-19\/11372434_121370084861088_569036911_a.jpg","id":"1543514582","full_name":""}]},"images":{"low_resolution":{"url":"https:\/\/scontent.cdninstagram.com\/hphotos-xfa1\/t51.2885-15\/s320x320\/e15\/11376629_1650859051814506_1184904295_n.jpg","width":320,"height":320},"thumbnail":{"url":"https:\/\/scontent.cdninstagram.com\/hphotos-xfa1\/t51.2885-15\/s150x150\/e15\/11376629_1650859051814506_1184904295_n.jpg","width":150,"height":150},"standard_resolution":{"url":"https:\/\/scontent.cdninstagram.com\/hphotos-xfa1\/t51.2885-15\/e15\/11376629_1650859051814506_1184904295_n.jpg","width":640,"height":640}},"users_in_photo":[],"caption":{"created_time":"1432856839","text":"I could have spent all day in this place \ud83c\udf33 #centralpark","from":{"username":"danielcalti5","profile_picture":"https:\/\/igcdn-photos-g-a.akamaihd.net\/hphotos-ak-xfa1\/t51.2885-19\/11856755_923037117760838_1573941093_a.jpg","id":"22447438","full_name":"Daniel Caltabiano"},"id":"995197760940940994"},"type":"image","id":"995197758743125222_22447438","user":{"username":"danielcalti5","profile_picture":"https:\/\/igcdn-photos-g-a.akamaihd.net\/hphotos-ak-xfa1\/t51.2885-19\/11856755_923037117760838_1573941093_a.jpg","id":"22447438","full_name":"Daniel Caltabiano"}},{"attribution":null,"tags":["magnoliabakery","newyorkcity","bananapudding","nyskyline","centralpark","sexandthecity"],"location":{"latitude":40.783055556,"name":"Central Park","longitude":-73.972222222,"id":254433809},"comments":{"count":0,"data":[]},"filter":"Normal","created_time":"1432852318","link":"https:\/\/instagram.com\/p\/3PhJmYuc14\/","likes":{"count":17,"data":[{"username":"antonio.joao.matos","profile_picture":"https:\/\/igcdn-photos-e-a.akamaihd.net\/hphotos-ak-xap1\/t51.2885-19\/928068_314199648749884_322949807_a.jpg","id":"1457347368","full_name":"Jo\u00e3o Matos"},{"username":"angelicatibbling","profile_picture":"https:\/\/igcdn-photos-b-a.akamaihd.net\/hphotos-ak-xpf1\/t51.2885-19\/s150x150\/1389407_1017177538322769_242873003_a.jpg","id":"1466817488","full_name":"Ang\u00e9lica Tibbling"},{"username":"nacchan052","profile_picture":"https:\/\/scontent.cdninstagram.com\/hphotos-xaf1\/t51.2885-19\/s150x150\/11356963_1459874104321363_179042458_a.jpg","id":"888138066","full_name":"Natsuki Mochizuki"},{"username":"giovannicritti","profile_picture":"https:\/\/igcdn-photos-a-a.akamaihd.net\/hphotos-ak-xaf1\/t51.2885-19\/11906305_1242720472420720_664061536_a.jpg","id":"1094613341","full_name":"Giovanni Critti"}]},"images":{"low_resolution":{"url":"https:\/\/scontent.cdninstagram.com\/hphotos-xaf1\/t51.2885-15\/s320x320\/e15\/11282289_805516492866197_635649947_n.jpg","width":320,"height":320},"thumbnail":{"url":"https:\/\/scontent.cdninstagram.com\/hphotos-xaf1\/t51.2885-15\/s150x150\/e15\/11282289_805516492866197_635649947_n.jpg","width":150,"height":150},"standard_resolution":{"url":"https:\/\/scontent.cdninstagram.com\/hphotos-xaf1\/t51.2885-15\/e15\/11282289_805516492866197_635649947_n.jpg","width":640,"height":640}},"users_in_photo":[],"caption":{"created_time":"1432852318","text":"Banana pudding from #magnoliabakery, so nhami!\n#bananapudding #sexandthecity #centralpark #newyorkcity #nyskyline","from":{"username":"claudiareginamatos","profile_picture":"https:\/\/scontent.cdninstagram.com\/hphotos-xfa1\/t51.2885-19\/s150x150\/11821301_1436788299983687_1466816470_a.jpg","id":"236208698","full_name":"claudiaregina"},"id":"995175178759163416"},"type":"image","id":"995159837899345272_236208698","user":{"username":"claudiareginamatos","profile_picture":"https:\/\/scontent.cdninstagram.com\/hphotos-xfa1\/t51.2885-19\/s150x150\/11821301_1436788299983687_1466816470_a.jpg","id":"236208698","full_name":"claudiaregina"}}]}'
+    http_version: 
+  recorded_at: Sat, 15 Aug 2015 02:09:08 GMT
+recorded_with: VCR 2.9.3


### PR DESCRIPTION
This pull request adds support for Instagram's location subscriptions. These are very similar to geography subscriptions in behavior.

**To setup a location subscription:**

``` bash
# First find a location to subscribe to: https://api.instagram.com/v1/locations/search?lat=40.782956&lng=-73.972106&distance=5000&client_id=YOUR_CLIENT_ID
# Hostname (or URL), Location Object ID
rake butterfli:instagram:subscription:location:setup['yourhost.com',254433809]
```

Just like geography, you can listen for new stories using `Butterfli.subscribe`. Currently, there is no differentiation between APIs (e.g. geography vs location), so the stories will appear as a single stream.
