### PR TITLE
Add tag subscription

### DIFF
--- a/app/controllers/butterfli/instagram/rails/subscription/tag_controller.rb
+++ b/app/controllers/butterfli/instagram/rails/subscription/tag_controller.rb
@@ -1,0 +1,41 @@
+class Butterfli::Instagram::Rails::Subscription::TagController < Butterfli::Instagram::Rails::SubscriptionController
+  def callback
+    tag_object_id = nil
+    media_objects = nil
+
+    # Step #1: Callback to Instagram and retrieve the media metadata
+    client.process_subscription(request.raw_post) do |handler|
+      handler.on_tag_changed do |id, data|
+        tag_object_id = id
+        media_objects = client.tag_recent_media(tag_object_id, min_id: self.class.subscriptions[tag_object_id])
+      end
+    end
+
+    # Step #2: Filter images to uniques
+    media_objects = media_objects.uniq { |item| item['id'] }
+
+    stories = []
+    if !media_objects.empty?
+      # Step #3: Transform image metadata using Butterfli
+      media_objects.each do |media_object|
+        story = Butterfli::Instagram::Data::MediaObject.new(media_object).transform
+        stories << story if story
+      end
+
+      # Step #3.1: Update the 'last seen photo ID', for 'pagination'
+      # NOTE: If we're receiving objects from multiple overlapping tags,
+      #       it's entirely possible we'd be collecting duplicate stories...
+      self.class.subscriptions[tag_object_id] = media_objects.collect(&:id).max
+    end
+
+    # Step #4: Notify Instagram subscribers
+    Butterfli.syndicate(stories) if !stories.empty?
+
+    # Step #5: Render output
+    respond_to do |format|
+      format.html { render text: "#{stories.to_json}" }
+      format.json { render text: "#{stories.to_json}" }
+      format.text { render text: "#{stories.to_json}" }
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,10 @@ Butterfli::Instagram::Rails::Engine.routes.draw do
         get 'callback', to: '/butterfli/instagram/rails/subscription/location#setup'
         post 'callback', to: '/butterfli/instagram/rails/subscription/location#callback'
       end
+      namespace :tag do
+        get 'callback', to: '/butterfli/instagram/rails/subscription/tag#setup'
+        post 'callback', to: '/butterfli/instagram/rails/subscription/tag#callback'
+      end
     end
   end
 end

--- a/lib/butterfli/instagram/rails/tasks.rb
+++ b/lib/butterfli/instagram/rails/tasks.rb
@@ -6,6 +6,7 @@ module Butterfli::Instagram::Tasks
   engine Butterfli::Instagram::Rails::Engine
   controller :geography, "Butterfli::Instagram::Rails::Subscription::GeographyController"
   controller :location, "Butterfli::Instagram::Rails::Subscription::LocationController"
+  controller :tag, "Butterfli::Instagram::Rails::Subscription::TagController"
 
   # NOTE: Must be forcefully overidden to use the Rails module...
   def self.configure; super; end

--- a/spec/controllers/subscription/tag_controller_spec.rb
+++ b/spec/controllers/subscription/tag_controller_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+RSpec.describe Butterfli::Instagram::Rails::Subscription::TagController, type: :controller do
+  routes { Butterfli::Instagram::Rails::Engine.routes }
+
+  # Configure the Instagram client...
+  before { configure_for_instagram }
+
+  # Default examples
+  it_behaves_like "an Instagram subscription controller", Butterfli::Instagram::Rails::Subscription::TagController, "tag"
+end

--- a/spec/fixtures/inbound/subscription/tag/callback/default.yml
+++ b/spec/fixtures/inbound/subscription/tag/callback/default.yml
@@ -1,0 +1,24 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:3000/instagram/subscription/tag/callback
+    path: "/instagram/subscription/tag/callback"
+    query_string: ''
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"changed_aspect": "media", "object": "tag", "object_id": "nyc", "time":
+        1441406814, "subscription_id": 19787303, "data": {}}]'
+    headers:
+      Host:
+      - localhost:3000
+      X-Hub-Signature:
+      - ea2869c235744e4847672162bbe4a75144ff1fa9
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Python-httplib2/0.8 (gzip)
+      Version:
+      - HTTP/1.1
+  recorded_at: '2015-09-04T18:47:05-04:00'
+recorded_with: Butterfli Rack Recorder

--- a/spec/fixtures/inbound/subscription/tag/callback/unauthorized_bad_signature.yml
+++ b/spec/fixtures/inbound/subscription/tag/callback/unauthorized_bad_signature.yml
@@ -1,0 +1,24 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:3000/instagram/subscription/tag/callback
+    path: "/instagram/subscription/tag/callback"
+    query_string: ''
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"changed_aspect": "media", "object": "tag", "object_id": "nyc", "time":
+        1441406814, "subscription_id": 19787303, "data": {}}]'
+    headers:
+      Host:
+      - localhost:3000
+      X-Hub-Signature:
+      - 386622c374528de5b4a5bce1ac97ec3b5ba0ddf6
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Python-httplib2/0.8 (gzip)
+      Version:
+      - HTTP/1.1
+  recorded_at: '2015-09-04T18:47:05-04:00'
+recorded_with: Butterfli Rack Recorder

--- a/spec/fixtures/inbound/subscription/tag/callback/unauthorized_missing_signature.yml
+++ b/spec/fixtures/inbound/subscription/tag/callback/unauthorized_missing_signature.yml
@@ -1,0 +1,22 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:3000/instagram/subscription/tag/callback
+    path: "/instagram/subscription/tag/callback"
+    query_string: ''
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"changed_aspect": "media", "object": "tag", "object_id": "nyc", "time":
+        1441406814, "subscription_id": 19787303, "data": {}}]'
+    headers:
+      Host:
+      - localhost:3000
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Python-httplib2/0.8 (gzip)
+      Version:
+      - HTTP/1.1
+  recorded_at: '2015-09-04T18:47:05-04:00'
+recorded_with: Butterfli Rack Recorder

--- a/spec/fixtures/inbound/subscription/tag/setup/default.yml
+++ b/spec/fixtures/inbound/subscription/tag/setup/default.yml
@@ -1,0 +1,21 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3000/instagram/subscription/tag/callback?hub.verify_token=verify_token&hub.challenge=30f18cedbe3941ea9fd57967d8402922&hub.mode=subscribe
+    path: "/instagram/subscription/tag/callback"
+    query_string: hub.verify_token=verify_token&hub.challenge=30f18cedbe3941ea9fd57967d8402922&hub.mode=subscribe
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Host:
+      - localhost:3000
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Python-httplib2/0.8 (gzip)
+      Version:
+      - HTTP/1.1
+  recorded_at: '2015-09-04T18:56:05-04:00'
+recorded_with: Butterfli Rack Recorder

--- a/spec/fixtures/inbound/subscription/tag/setup/unauthorized_missing_token.yml
+++ b/spec/fixtures/inbound/subscription/tag/setup/unauthorized_missing_token.yml
@@ -1,0 +1,21 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3000/instagram/subscription/tag/callback?hub.challenge=30f18cedbe3941ea9fd57967d8402922&hub.mode=subscribe
+    path: "/instagram/subscription/tag/callback"
+    query_string: hub.challenge=30f18cedbe3941ea9fd57967d8402922&hub.mode=subscribe
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Host:
+      - localhost:3000
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Python-httplib2/0.8 (gzip)
+      Version:
+      - HTTP/1.1
+  recorded_at: '2015-09-04T18:56:05-04:00'
+recorded_with: Butterfli Rack Recorder

--- a/spec/fixtures/outbound/subscription/tag/callback/default.yml
+++ b/spec/fixtures/outbound/subscription/tag/callback/default.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.instagram.com/v1/tags/nyc/media/recent.json?min_id&client_id=client_id
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json; charset=utf-8
+      User-Agent:
+      - Instagram Ruby Gem 1.1.5
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      x-ratelimit-remaining:
+      - '4994'
+      content-language:
+      - en
+      expires:
+      - Sat, 01 Jan 2000 00:00:00 GMT
+      vary:
+      - Cookie, Accept-Language, Accept-Encoding
+      x-ratelimit-limit:
+      - '5000'
+      pragma:
+      - no-cache
+      cache-control:
+      - private, no-cache, no-store, must-revalidate
+      date:
+      - Sat, 15 Aug 2015 02:09:07 GMT
+      content-type:
+      - application/json; charset=utf-8
+      set-cookie:
+      - csrftoken=323258bae9c2f6f3f379dd1d752818f9; expires=Sat, 13-Aug-2016 02:09:07
+        GMT; Max-Age=31449600; Path=/
+      connection:
+      - keep-alive
+      content-length:
+      - '1234'
+    body:
+      encoding: UTF-8
+      string: '{"pagination":{"next_max_tag_id":"1066933327186955361","deprecation_warning":"next_max_id and min_id are deprecated for this endpoint; use min_tag_id and max_tag_id instead","next_max_id":"1066933327186955361","next_min_id":"1066933534655105472","min_tag_id":"1066933534655105472","next_url":"https:\/\/api.instagram.com\/v1\/tags\/nyc\/media\/recent?client_id=f3fe014c5b9e4ef9982b94224a5083f4\u0026max_tag_id=1066933327186955361"},"meta":{"code":200},"data":[{"attribution":null,"tags":["nyc","grubbin","ny"],"location":null,"comments":{"count":0,"data":[]},"filter":"Sierra","created_time":"1441408409","link":"https:\/\/instagram.com\/p\/7OgmM-ncN9\/","likes":{"count":0,"data":[]},"images":{"low_resolution":{"url":"https:\/\/scontent.cdninstagram.com\/hphotos-xaf1\/t51.2885-15\/s320x320\/e35\/11809758_544331475714926_1641285913_n.jpg","width":320,"height":320},"thumbnail":{"url":"https:\/\/scontent.cdninstagram.com\/hphotos-xaf1\/t51.2885-15\/s150x150\/e35\/11809758_544331475714926_1641285913_n.jpg","width":150,"height":150},"standard_resolution":{"url":"https:\/\/scontent.cdninstagram.com\/hphotos-xaf1\/t51.2885-15\/s640x640\/sh0.08\/e35\/11809758_544331475714926_1641285913_n.jpg","width":640,"height":640}},"users_in_photo":[],"caption":{"created_time":"1441408409","text":"Off guardd \ud83d\udcf7 ..\nThanks to baee \ud83d\ude11 smhh .. you dont wnna play that gamee @chay_lalinda \n#grubbin #nyc #ny","from":{"username":"speechlessswag","profile_picture":"https:\/\/igcdn-photos-e-a.akamaihd.net\/hphotos-ak-xaf1\/t51.2885-19\/s150x150\/11410464_605659719537324_1241421860_a.jpg","id":"19036903","full_name":"Swag Acevedo"},"id":"1066933531367555836"},"type":"image","id":"1066933524497286013_19036903","user":{"username":"speechlessswag","profile_picture":"https:\/\/igcdn-photos-e-a.akamaihd.net\/hphotos-ak-xaf1\/t51.2885-19\/s150x150\/11410464_605659719537324_1241421860_a.jpg","id":"19036903","full_name":"Swag Acevedo"}},{"attribution":null,"tags":["nyc","statueofliberty"],"location":{"latitude":40.689265147,"name":"Statue of Liberty National Monument","longitude":-74.044534373,"id":212911294},"comments":{"count":0,"data":[]},"filter":"Clarendon","created_time":"1441408408","link":"https:\/\/instagram.com\/p\/7OgmKxG_IK\/","likes":{"count":0,"data":[]},"images":{"low_resolution":{"url":"https:\/\/scontent.cdninstagram.com\/hphotos-xfa1\/t51.2885-15\/s320x320\/e35\/11821721_977906262261912_1200158342_n.jpg","width":320,"height":320},"thumbnail":{"url":"https:\/\/scontent.cdninstagram.com\/hphotos-xfa1\/t51.2885-15\/s150x150\/e35\/11821721_977906262261912_1200158342_n.jpg","width":150,"height":150},"standard_resolution":{"url":"https:\/\/scontent.cdninstagram.com\/hphotos-xfa1\/t51.2885-15\/s640x640\/sh0.08\/e35\/11821721_977906262261912_1200158342_n.jpg","width":640,"height":640}},"users_in_photo":[],"caption":{"created_time":"1441408408","text":"#nyc #statueofliberty","from":{"username":"lukassteff","profile_picture":"https:\/\/igcdn-photos-b-a.akamaihd.net\/hphotos-ak-xap1\/t51.2885-19\/s150x150\/928293_1188957967787833_549480954_a.jpg","id":"2159386787","full_name":""},"id":"1066933524052570923"},"type":"image","id":"1066933522123190794_2159386787","user":{"username":"lukassteff","profile_picture":"https:\/\/igcdn-photos-b-a.akamaihd.net\/hphotos-ak-xap1\/t51.2885-19\/s150x150\/928293_1188957967787833_549480954_a.jpg","id":"2159386787","full_name":""}}]}'
+    http_version: 
+  recorded_at: Sat, 15 Aug 2015 02:09:08 GMT
+recorded_with: VCR 2.9.3


### PR DESCRIPTION
This pull request adds support for Instagram's tag subscriptions. These are very similar to location & geography subscriptions in behavior.

**To setup a tag subscription:**

``` bash
# First find a tag to subscribe to: https://api.instagram.com/v1/tags/search?q=TAG_NAME&client_id=YOUR_CLIENT_ID
# Hostname (or URL), Tag Name
rake butterfli:instagram:subscription:tag:setup['yourhost.com','nyc']
```

Just like geography & location, you can listen for new stories using `Butterfli.subscribe`. Currently, there is no differentiation between APIs (e.g. tags vs others), so the stories will appear as a single stream.

**NOTE:** It appears that certain tags can be _very_ high volume (2-3/sec.) Since these subscription controllers do an Instagram query per Instagram callback, this can cut dramatically into your API quota/hour (currently 5000/hour) if not exercised with caution. We should add a throttle mechanism to prevent exceeding this quota.
